### PR TITLE
chore: silence ExecuTorch debug logging + FFmpeg banner noise

### DIFF
--- a/lib/helpers/separation/audio_io.dart
+++ b/lib/helpers/separation/audio_io.dart
@@ -26,6 +26,7 @@ Future<List<Float32List>> decodeToFloatPcm(
   // can map straight into a Float32List on every (little-endian) target.
   try {
     final session = await FFmpegKit.execute(
+      '-hide_banner -loglevel error '
       '-y -i "$inputPath" -ac $channels -ar $sampleRate '
       '-f f32le -acodec pcm_f32le "$rawPath"',
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,8 @@ import 'package:get/get.dart';
 import 'dart:async';
 import 'dart:io';
 
+import 'package:executorch_flutter/executorch_flutter.dart';
+
 import 'constants.dart' show Models;
 import 'helpers/separation/executorch_demixing_engine.dart';
 import 'models/model.dart';
@@ -28,6 +30,10 @@ import 'providers/preferences_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // ExecuTorch enables verbose debug logging by default ('[ExecuTorch DEBUG]
+  // …' on every load/inference). Turn it off so the console isn't spammed.
+  await ExecutorchManager.instance.setDebugLogging(false);
 
   await Hive.initFlutter();
 


### PR DESCRIPTION
Quiets the noisy startup/runtime console output.

- **ExecuTorch debug logging** is on by default (`[ExecuTorch DEBUG] …` on every load + each `forwardAsync`). Disabled once in `main()` via `ExecutorchManager.setDebugLogging(false)`.
- **FFmpeg** decode now runs with `-hide_banner -loglevel error`, suppressing the build banner and the `all_channel_counts` deprecation notice.

Done on a branch per request (not pushed to main directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)