### PR TITLE
chore: rename user-facing app name to Demixr

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleDisplayName</key>
-		<string>Demixr App</string>
+		<string>Demixr</string>
 		<key>CFBundleExecutable</key>
 		<string>$(EXECUTABLE_NAME)</string>
 		<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
 		<key>CFBundleName</key>
-		<string>demixr_app</string>
+		<string>Demixr</string>
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = demixr_app
+PRODUCT_NAME = Demixr
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.demixr.demixrApp


### PR DESCRIPTION
## What

Rename the user-facing app name to **Demixr** across platforms. No identifiers change.

### Changes
- **macOS** `macos/Runner/Configs/AppInfo.xcconfig`: `PRODUCT_NAME = demixr_app` → `Demixr`. `Info.plist` already uses `$(PRODUCT_NAME)` for `CFBundleName`, so the build now produces `Demixr.app`.
- **iOS** `ios/Runner/Info.plist`: `CFBundleName` `demixr_app` → `Demixr`; `CFBundleDisplayName` `Demixr App` → `Demixr` (consistency).
- **Android**: no change — `AndroidManifest.xml` `android:label` was already `Demixr`.

### Unchanged (by design)
- Bundle identifier `com.demixr.demixrApp`
- Dart package name `demixr_app` (pubspec `name:`)
- Android `applicationId` / `namespace`

## Verification
- `flutter build macos --release` succeeded; `build/macos/Build/Products/Release/` contains **`Demixr.app`**.
- `.github/workflows/release_app.yml` macOS `.dmg` step globs `*.app` (`ls -d build/macos/Build/Products/Release/*.app`) — not hardcoded to `demixr_app.app`, so the rename does not break packaging.

Release is arm64-only by design (ExecuTorch prebuilt is arm64-only) — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)