### PR TITLE
Fix build warnings and add iOS simulator support

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,9 +2,9 @@ org.gradle.jvmargs=-Xmx4096M
 android.useAndroidX=true
 android.enableJetifier=true
 # This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
+android.builtInKotlin=true
 # This newDsl flag was added automatically by Flutter migrator
-android.newDsl=false
+android.newDsl=true
 
-# Use a current Kotlin (Flutter bundles 2.0.0; latest stable Kotlin; warns to upgrade to >=2.2.20)
+# Kotlin version exposed to native plugins that still read the legacy property.
 kotlin_version=2.4.0

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2,12 +2,8 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
-    override func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -24,6 +24,27 @@
 		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
+		<key>UIApplicationSceneManifest</key>
+		<dict>
+			<key>UIApplicationSupportsMultipleScenes</key>
+			<false/>
+			<key>UISceneConfigurations</key>
+			<dict>
+				<key>UIWindowSceneSessionRoleApplication</key>
+				<array>
+					<dict>
+						<key>UISceneClassName</key>
+						<string>UIWindowScene</string>
+						<key>UISceneDelegateClassName</key>
+						<string>FlutterSceneDelegate</string>
+						<key>UISceneConfigurationName</key>
+						<string>flutter</string>
+						<key>UISceneStoryboardFile</key>
+						<string>Main</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
 		<key>UILaunchStoryboardName</key>
 		<string>LaunchScreen</string>
 		<key>UIMainStoryboardFile</key>

--- a/lib/components/song_widget.dart
+++ b/lib/components/song_widget.dart
@@ -71,22 +71,27 @@ class AlbumCover extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget fallbackCover() => Image.asset(
+      getAssetPath('default_cover', AssetType.image),
+      fit: BoxFit.cover,
+      width: size,
+      height: size,
+    );
+
     return ClipRRect(
       borderRadius: BorderRadius.circular(size == null ? 16 : size! * .1),
-      child: imagePath.fold(
-        (failure) => Image.asset(
-          getAssetPath('default_cover', AssetType.image),
+      child: imagePath.fold((failure) => fallbackCover(), (coverPath) {
+        final cover = File(coverPath);
+        if (!cover.existsSync()) return fallbackCover();
+
+        return Image.file(
+          cover,
           fit: BoxFit.cover,
           width: size,
           height: size,
-        ),
-        (coverPath) => Image.file(
-          File(coverPath),
-          fit: BoxFit.cover,
-          width: size,
-          height: size,
-        ),
-      ),
+          errorBuilder: (context, error, stackTrace) => fallbackCover(),
+        );
+      }),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:demixr_app/models/duration_adapter.dart';
 import 'package:demixr_app/models/unmixed_song.dart';
 import 'package:demixr_app/providers/library_provider.dart';
 import 'package:demixr_app/providers/model_provider.dart';
@@ -36,7 +37,7 @@ Future<void> main() async {
   Hive.registerAdapters();
 
   await Hive.openBox<dynamic>(BoxesNames.preferences);
-  await Hive.openBox<UnmixedSong>(BoxesNames.library);
+  await _openLibraryWithLegacyDurationMigration();
 
   runApp(const MyApp());
 
@@ -44,6 +45,25 @@ Future<void> main() async {
   // of the session isn't stalled by the one-time CoreML compile. Background +
   // best-effort.
   unawaited(_warmUpSelectedModel());
+}
+
+Future<void> _openLibraryWithLegacyDurationMigration() async {
+  try {
+    await Hive.openBox<UnmixedSong>(BoxesNames.library);
+  } on HiveError catch (error) {
+    // Older Demixr versions stored Duration with the app adapter typeId 1,
+    // encoded by Hive CE as on-disk typeId 33. Read that format once, then
+    // recreate the box so Hive's built-in Duration adapter is used afterward.
+    if (!error.message.contains('unknown typeId: 33')) rethrow;
+
+    Hive.registerAdapter<Duration>(DurationAdapter());
+    final legacyBox = await Hive.openBox<UnmixedSong>(BoxesNames.library);
+    final songs = legacyBox.toMap();
+    await legacyBox.deleteFromDisk();
+
+    final migratedBox = await Hive.openBox<UnmixedSong>(BoxesNames.library);
+    await migratedBox.putAll(songs);
+  }
 }
 
 Future<void> _warmUpSelectedModel() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:demixr_app/models/duration_adapter.dart';
 import 'package:demixr_app/models/unmixed_song.dart';
 import 'package:demixr_app/providers/library_provider.dart';
 import 'package:demixr_app/providers/model_provider.dart';
@@ -32,11 +31,9 @@ Future<void> main() async {
 
   await Hive.initFlutter();
 
-  // Generated registrar covers the @HiveType adapters (UnmixedSong); the
-  // hand-written Duration adapter is registered explicitly.
-  Hive
-    ..registerAdapters()
-    ..registerAdapter(DurationAdapter());
+  // Hive CE already registers its built-in Duration adapter. Register only
+  // the app's generated model adapters here.
+  Hive.registerAdapters();
 
   await Hive.openBox<dynamic>(BoxesNames.preferences);
   await Hive.openBox<UnmixedSong>(BoxesNames.library);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,20 +33,20 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.9
-  equatable: ^2.0.8
+  equatable: ^2.1.0
   flutter_svg: ^2.3.0
   intersperse: ^2.0.0
   file_picker: ^11.0.2
   audio_metadata_reader: ^1.6.0
   dartz: ^0.10.1
-  dio: ^5.9.2
+  dio: ^5.10.0
   http: ^1.6.0
   provider: ^6.1.5+1
   path: ^1.9.1
   path_provider: ^2.1.5
   get: ^4.7.3
   async: ^2.13.1
-  audioplayers: ^6.7.1
+  audioplayers: ^6.8.1
   audio_video_progress_bar: ^2.0.3
   url_launcher: ^6.3.2
   percent_indicator: ^4.2.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   audio_video_progress_bar: ^2.0.3
   url_launcher: ^6.3.2
   percent_indicator: ^4.2.5
-  ffmpeg_kit_flutter_new_audio: ^2.0.0
+  ffmpeg_kit_flutter_new_audio: ^2.2.2
   flutter_onnxruntime: ^1.8.0
   executorch_flutter: ^0.4.1
   youtube_explode_dart: ^3.1.0


### PR DESCRIPTION
## What changed

- upgraded the FFmpeg audio package for Apple Silicon iOS simulator support
- migrated the iOS runner to the required `UIScene` lifecycle
- enabled Flutter's Built-in Kotlin and new Android DSL and upgraded compatible dependencies
- added safe fallback rendering for stale library cover paths
- added a one-time migration for legacy Hive duration records

## Why

The modernized UI branch built on Android and macOS, but the previous FFmpeg binary could not target an Apple Silicon iOS simulator. Existing app data could also prevent startup after dependency and simulator-container changes, resulting in black screens on iOS and macOS.

## Impact

The app now builds and launches on iPhone, Android, and macOS while preserving existing library data. Missing cover files fall back to default artwork, and legacy Hive data is migrated automatically.

## Validation

- `flutter analyze`
- `flutter test` (8 tests)
- Android debug APK build and Pixel 10 Pro XL emulator launch
- iOS simulator build and iPhone 17 simulator launch
- macOS debug build and two consecutive runtime launches after data migration
