### PR TITLE
Add system media controls, stem mixing, and exports

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
    <application
         android:label="Demixr"
         android:name="${applicationName}"
@@ -29,6 +33,23 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <service
+            android:name="com.ryanheise.audioservice.AudioService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="true"
+            tools:ignore="Instantiatable">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
+        </service>
+        <receiver
+            android:name="com.ryanheise.audioservice.MediaButtonReceiver"
+            android:exported="true"
+            tools:ignore="Instantiatable">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
     </application>
     <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/android/app/src/main/kotlin/com/demixr/demixr_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/demixr/demixr_app/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.demixr.demixr_app
 
-import io.flutter.embedding.android.FlutterActivity
+import com.ryanheise.audioservice.AudioServiceActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : AudioServiceActivity()

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -24,6 +24,10 @@
 		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
+		<key>UIBackgroundModes</key>
+		<array>
+			<string>audio</string>
+		</array>
 		<key>UIApplicationSceneManifest</key>
 		<dict>
 			<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,8 @@ import 'package:demixr_app/screens/error/error_screen.dart';
 import 'package:demixr_app/screens/home/home_screen.dart';
 import 'package:demixr_app/screens/player/player_screen.dart';
 import 'package:demixr_app/screens/youtube/youtube_screen.dart';
+import 'package:demixr_app/services/system_media_handler.dart';
+import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:demixr_app/constants.dart' show BoxesNames, ColorPalette;
 import 'package:flutter/services.dart';
@@ -27,6 +29,8 @@ import 'models/model.dart';
 import 'repositories/preferences_repository.dart';
 import 'providers/preferences_provider.dart';
 
+late final SystemMediaHandler systemMediaHandler;
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -38,6 +42,18 @@ Future<void> main() async {
 
   await Hive.openBox<dynamic>(BoxesNames.preferences);
   await _openLibraryWithLegacyDurationMigration();
+
+  await AudioService.init(
+    builder: () {
+      systemMediaHandler = SystemMediaHandler();
+      return systemMediaHandler;
+    },
+    config: const AudioServiceConfig(
+      androidNotificationChannelId: 'com.demixr.demixrApp.playback',
+      androidNotificationChannelName: 'Music playback',
+      androidNotificationOngoing: true,
+    ),
+  );
 
   runApp(const MyApp());
 
@@ -131,9 +147,9 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           create: (_) => LibraryProvider(),
         ),
         ChangeNotifierProxyProvider<LibraryProvider, PlayerProvider>(
-          create: (context) => PlayerProvider(),
+          create: (context) => PlayerProvider(systemMediaHandler),
           update: (context, library, player) =>
-              (player ?? PlayerProvider())..update(library),
+              (player ?? PlayerProvider(systemMediaHandler))..update(library),
         ),
       ],
       child: GetMaterialApp(

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -38,6 +38,8 @@ class PlayerProvider extends ChangeNotifier {
   /// Checks if a [stem] is muted or not.
   bool isStemMute(Stem stem) => _player.getStemState(stem) == StemState.mute;
 
+  double stemVolume(Stem stem) => _player.getStemVolume(stem);
+
   /// Handles the updates of the [library].
   ///
   /// Start playing a new song if another song was selected from the library.
@@ -144,6 +146,11 @@ class PlayerProvider extends ChangeNotifier {
   /// Toggle mute / unmute on the given [stem].
   void toggleStem(Stem stem) {
     _player.toggleStem(stem);
+    notifyListeners();
+  }
+
+  void setStemVolume(Stem stem, double volume) {
+    _player.setStemVolume(stem, volume);
     notifyListeners();
   }
 }

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -59,6 +59,12 @@ class PlayerProvider extends ChangeNotifier {
   List<Stem> get stems =>
       _song.fold((failure) => const [], (song) => song.stems);
 
+  UnmixedSong? get currentSong => _song.fold((failure) => null, (song) => song);
+
+  Map<Stem, double> get stemVolumes => {
+    for (final stem in stems) stem: _player.getStemVolume(stem),
+  };
+
   /// Checks if a [stem] is muted or not.
   bool isStemMute(Stem stem) => _player.getStemState(stem) == StemState.mute;
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:dartz/dartz.dart';
+import 'dart:async';
 
 import '../models/failure/failure.dart';
 import '../models/failure/no_song_selected.dart';
 import '../models/unmixed_song.dart';
 import '../providers/library_provider.dart';
 import '../services/stems_player.dart';
+import '../services/system_media_handler.dart';
 import '../constants.dart';
 
 /// The sate of the music player.
@@ -15,11 +17,33 @@ enum PlayerState { play, pause, off }
 ///
 /// Uses the [StemsPlayer] to play the different stems of the [_song].
 class PlayerProvider extends ChangeNotifier {
+  final SystemMediaHandler _mediaHandler;
   late LibraryProvider _library;
   Either<Failure, UnmixedSong> _song = Left(NoSongSelected());
   final _player = StemsPlayer();
   PlayerState state = PlayerState.off;
   Duration position = Duration.zero;
+  StreamSubscription<Duration>? _positionSubscription;
+
+  PlayerProvider(this._mediaHandler) {
+    _mediaHandler.attach(
+      play: () async => play(),
+      pause: () async => pause(),
+      seek: (position) async => seek(position),
+      next: () async => next(),
+      previous: () async => previous(),
+    );
+    _positionSubscription = positionStream.listen((position) {
+      this.position = position;
+      _publishMediaState();
+    });
+  }
+
+  @override
+  void dispose() {
+    _positionSubscription?.cancel();
+    super.dispose();
+  }
 
   /// The state of the player, playing or not.
   bool get isPlaying => state == PlayerState.play;
@@ -60,8 +84,10 @@ class PlayerProvider extends ChangeNotifier {
       _song.fold((failure) => null, (song) {
         _player.setUrls(song);
         _player.seek(position);
+        _mediaHandler.publishSong(song);
 
         state = PlayerState.pause;
+        _publishMediaState();
 
         _player.onPlayerCompletion.listen((event) {
           toStart(setPause: true);
@@ -104,12 +130,16 @@ class PlayerProvider extends ChangeNotifier {
   void resume() {
     _player.resume();
     state = PlayerState.play;
+    _publishMediaState();
+    notifyListeners();
   }
 
   /// Pauses the current [_song].
   void pause() {
     _player.pause();
     state = PlayerState.pause;
+    _publishMediaState();
+    notifyListeners();
   }
 
   /// Stops playing the current [_song], and unload it.
@@ -124,6 +154,19 @@ class PlayerProvider extends ChangeNotifier {
   void seek(Duration position) {
     this.position = position;
     _player.seek(position);
+    _publishMediaState();
+  }
+
+  void play() {
+    if (state != PlayerState.off) resume();
+  }
+
+  void _publishMediaState() {
+    _mediaHandler.publishState(
+      playing: isPlaying,
+      position: position,
+      bufferedPosition: songDuration,
+    );
   }
 
   /// Play the next song in the [_library].

--- a/lib/screens/player/components/infos_dialog.dart
+++ b/lib/screens/player/components/infos_dialog.dart
@@ -124,9 +124,12 @@ class _ExportDialogState extends State<_ExportDialog> {
                     leading: const Icon(Icons.tune_rounded),
                     title: const Text('Current remix'),
                     subtitle: const Text('Uses the current stem levels'),
-                    onTap: () => _run(
-                      () => _exporter.exportRemix(song, player.stemVolumes),
-                    ),
+                    onTap: () {
+                      final gains = Map<Stem, double>.unmodifiable(
+                        player.stemVolumes,
+                      );
+                      _run(() => _exporter.exportRemix(song, gains));
+                    },
                   ),
                   ListTile(
                     leading: const Icon(Icons.music_note_rounded),

--- a/lib/screens/player/components/infos_dialog.dart
+++ b/lib/screens/player/components/infos_dialog.dart
@@ -1,4 +1,6 @@
 import 'package:demixr_app/providers/library_provider.dart';
+import 'package:demixr_app/providers/player_provider.dart';
+import 'package:demixr_app/services/song_export_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get/route_manager.dart';
 import 'package:provider/provider.dart';
@@ -47,7 +49,112 @@ class InfosDialog extends StatelessWidget {
           ],
         ),
       ),
-      actions: [TextButton(onPressed: Get.back, child: const Text('Done'))],
+      actions: [
+        TextButton.icon(
+          onPressed: () => showDialog(
+            context: context,
+            builder: (context) => const _ExportDialog(),
+          ),
+          icon: const Icon(Icons.ios_share_rounded),
+          label: const Text('Export'),
+        ),
+        TextButton(onPressed: Get.back, child: const Text('Done')),
+      ],
+    );
+  }
+}
+
+class _ExportDialog extends StatefulWidget {
+  const _ExportDialog();
+
+  @override
+  State<_ExportDialog> createState() => _ExportDialogState();
+}
+
+class _ExportDialogState extends State<_ExportDialog> {
+  final _exporter = SongExportService();
+  bool _busy = false;
+
+  Future<void> _run(Future<bool> Function() export) async {
+    setState(() => _busy = true);
+    try {
+      final saved = await export();
+      if (!mounted || !saved) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Export saved successfully.')),
+      );
+      Navigator.of(context).pop();
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Export failed: $error')));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final player = context.read<PlayerProvider>();
+    final song = player.currentSong;
+    if (song == null) return const SizedBox.shrink();
+
+    return AlertDialog(
+      backgroundColor: ColorPalette.surfaceContainer,
+      title: const Text('Export song'),
+      content: SizedBox(
+        width: 380,
+        child: _busy
+            ? const Padding(
+                padding: EdgeInsets.all(32),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CircularProgressIndicator(),
+                    SizedBox(height: 16),
+                    Text('Preparing export…'),
+                  ],
+                ),
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.tune_rounded),
+                    title: const Text('Current remix'),
+                    subtitle: const Text('Uses the current stem levels'),
+                    onTap: () => _run(
+                      () => _exporter.exportRemix(song, player.stemVolumes),
+                    ),
+                  ),
+                  ListTile(
+                    leading: const Icon(Icons.music_note_rounded),
+                    title: const Text('Original song'),
+                    subtitle: const Text('Audio before separation'),
+                    onTap: () => _run(() => _exporter.exportOriginal(song)),
+                  ),
+                  for (final stem in song.stems)
+                    ListTile(
+                      leading: const Icon(Icons.graphic_eq_rounded),
+                      title: Text('${stem.name} stem'),
+                      onTap: () => _run(() => _exporter.exportStem(song, stem)),
+                    ),
+                  ListTile(
+                    leading: const Icon(Icons.folder_zip_rounded),
+                    title: const Text('All stems'),
+                    subtitle: const Text('ZIP with stems and original'),
+                    onTap: () => _run(() => _exporter.exportAllStems(song)),
+                  ),
+                ],
+              ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _busy ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/player/components/infos_dialog.dart
+++ b/lib/screens/player/components/infos_dialog.dart
@@ -123,7 +123,14 @@ class _ExportDialogState extends State<_ExportDialog> {
                   ListTile(
                     leading: const Icon(Icons.tune_rounded),
                     title: const Text('Current remix'),
-                    subtitle: const Text('Uses the current stem levels'),
+                    subtitle: Text(
+                      player.stemVolumes.entries
+                          .map(
+                            (entry) =>
+                                '${entry.key.name} ${(entry.value * 100).round()}%',
+                          )
+                          .join(' · '),
+                    ),
                     onTap: () {
                       final gains = Map<Stem, double>.unmodifiable(
                         player.stemVolumes,

--- a/lib/screens/player/components/stem_selection.dart
+++ b/lib/screens/player/components/stem_selection.dart
@@ -56,54 +56,79 @@ class StemButton extends StatelessWidget {
     return Consumer<PlayerProvider>(
       builder: (context, player, child) {
         final isMuted = player.isStemMute(stem);
+        final volume = player.stemVolume(stem);
 
-        return Material(
-          color: isMuted
-              ? ColorPalette.surfaceContainerHigh
-              : ColorPalette.primary.withValues(alpha: 0.14),
-          borderRadius: BorderRadius.circular(12),
-          child: InkWell(
-            borderRadius: BorderRadius.circular(12),
-            onTap: () => player.toggleStem(stem),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
-              child: Row(
-                children: [
-                  Container(
-                    width: 8,
-                    height: 8,
-                    decoration: BoxDecoration(
-                      color: isMuted
-                          ? ColorPalette.onSurfaceVariant
-                          : ColorPalette.tertiary,
-                      shape: BoxShape.circle,
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            void updateVolume(double x) => player.setStemVolume(
+              stem,
+              (x / constraints.maxWidth).clamp(0.0, 1.0),
+            );
+
+            return Semantics(
+              label: '${stem.name} volume',
+              value: isMuted ? 'Muted' : '${(volume * 100).round()} percent',
+              slider: true,
+              increasedValue: '${((volume + .1).clamp(0, 1) * 100).round()}%',
+              decreasedValue: '${((volume - .1).clamp(0, 1) * 100).round()}%',
+              onIncrease: () =>
+                  player.setStemVolume(stem, (volume + .1).clamp(0, 1)),
+              onDecrease: () =>
+                  player.setStemVolume(stem, (volume - .1).clamp(0, 1)),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTapDown: (details) => updateVolume(details.localPosition.dx),
+                onHorizontalDragUpdate: (details) =>
+                    updateVolume(details.localPosition.dx),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: SizedBox(
+                    height: 52,
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        ColoredBox(color: ColorPalette.surfaceContainerHigh),
+                        FractionallySizedBox(
+                          alignment: Alignment.centerLeft,
+                          widthFactor: volume,
+                          child: ColoredBox(
+                            color: ColorPalette.primary.withValues(alpha: .34),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  stem.name,
+                                  style: TextStyle(
+                                    color: isMuted
+                                        ? ColorPalette.onSurfaceVariant
+                                        : ColorPalette.onSurface,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                              Icon(
+                                isMuted
+                                    ? Icons.volume_off_rounded
+                                    : Icons.volume_up_rounded,
+                                size: 20,
+                                color: isMuted
+                                    ? ColorPalette.onSurfaceVariant
+                                    : ColorPalette.tertiary,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      stem.name,
-                      style: TextStyle(
-                        color: isMuted
-                            ? ColorPalette.onSurfaceVariant
-                            : ColorPalette.onSurface,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                  Icon(
-                    isMuted
-                        ? Icons.volume_off_rounded
-                        : Icons.volume_up_rounded,
-                    size: 20,
-                    color: isMuted
-                        ? ColorPalette.onSurfaceVariant
-                        : ColorPalette.tertiary,
-                  ),
-                ],
+                ),
               ),
-            ),
-          ),
+            );
+          },
         );
       },
     );

--- a/lib/services/song_export_service.dart
+++ b/lib/services/song_export_service.dart
@@ -23,7 +23,10 @@ class SongExportService {
   );
 
   Future<bool> exportRemix(UnmixedSong song, Map<Stem, double> volumes) async {
-    if (song.stems.every((stem) => volumes[stem] == 1)) {
+    final gains = <Stem, double>{
+      for (final stem in song.stems) stem: (volumes[stem] ?? 1).clamp(0, 1),
+    };
+    if (song.stems.every((stem) => gains[stem] == 1)) {
       return _saveFile(
         File(song.mixture),
         '${sanitizeFilename(song.title)} - remix.wav',
@@ -37,16 +40,17 @@ class SongExportService {
       ),
     );
     final inputs = <String>[];
-    final filters = <String>[];
     final labels = <String>[];
     for (var index = 0; index < song.stems.length; index++) {
       final stem = song.stems[index];
       inputs.add('-i ${_quote(song.getStem(stem))}');
-      filters.add('[$index:a]volume=${volumes[stem] ?? 1}[a$index]');
-      labels.add('[a$index]');
+      labels.add('[$index:a]');
     }
+    final weights = song.stems
+        .map((stem) => gains[stem]!.toStringAsFixed(4))
+        .join(' ');
     final filter =
-        '${filters.join(';')};${labels.join()}amix=inputs=${song.stems.length}:normalize=0:dropout_transition=0[out]';
+        '${labels.join()}amix=inputs=${song.stems.length}:weights=\'$weights\':normalize=0:dropout_transition=0[out]';
     final session = await FFmpegKit.execute(
       '${inputs.join(' ')} -filter_complex ${_quote(filter)} -map "[out]" -c:a pcm_s16le -y ${_quote(output.path)}',
     );

--- a/lib/services/song_export_service.dart
+++ b/lib/services/song_export_service.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:ffmpeg_kit_flutter_new_audio/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_new_audio/return_code.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../constants.dart';
+import '../models/unmixed_song.dart';
+import '../utils.dart';
+
+class SongExportService {
+  Future<bool> exportOriginal(UnmixedSong song) => _saveFile(
+    File(song.mixture),
+    '${sanitizeFilename(song.title)} - original.wav',
+  );
+
+  Future<bool> exportStem(UnmixedSong song, Stem stem) => _saveFile(
+    File(song.getStem(stem)),
+    '${sanitizeFilename(song.title)} - ${stem.value}.wav',
+  );
+
+  Future<bool> exportRemix(UnmixedSong song, Map<Stem, double> volumes) async {
+    if (song.stems.every((stem) => volumes[stem] == 1)) {
+      return _saveFile(
+        File(song.mixture),
+        '${sanitizeFilename(song.title)} - remix.wav',
+      );
+    }
+
+    final output = File(
+      p.join(
+        (await getTemporaryDirectory()).path,
+        '${sanitizeFilename(song.title)}-remix-${DateTime.now().microsecondsSinceEpoch}.wav',
+      ),
+    );
+    final inputs = <String>[];
+    final filters = <String>[];
+    final labels = <String>[];
+    for (var index = 0; index < song.stems.length; index++) {
+      final stem = song.stems[index];
+      inputs.add('-i ${_quote(song.getStem(stem))}');
+      filters.add('[$index:a]volume=${volumes[stem] ?? 1}[a$index]');
+      labels.add('[a$index]');
+    }
+    final filter =
+        '${filters.join(';')};${labels.join()}amix=inputs=${song.stems.length}:normalize=0:dropout_transition=0[out]';
+    final session = await FFmpegKit.execute(
+      '${inputs.join(' ')} -filter_complex ${_quote(filter)} -map "[out]" -c:a pcm_s16le -y ${_quote(output.path)}',
+    );
+    final returnCode = await session.getReturnCode();
+    if (!ReturnCode.isSuccess(returnCode)) {
+      await output.deleteIfExists();
+      throw StateError('Could not render the remix.');
+    }
+
+    try {
+      return await _saveFile(
+        output,
+        '${sanitizeFilename(song.title)} - remix.wav',
+      );
+    } finally {
+      await output.deleteIfExists();
+    }
+  }
+
+  Future<bool> exportAllStems(UnmixedSong song) async {
+    final output = File(
+      p.join(
+        (await getTemporaryDirectory()).path,
+        '${sanitizeFilename(song.title)}-stems-${DateTime.now().microsecondsSinceEpoch}.zip',
+      ),
+    );
+    final encoder = ZipFileEncoder()..create(output.path);
+    try {
+      for (final stem in song.stems) {
+        await encoder.addFile(File(song.getStem(stem)), '${stem.value}.wav');
+      }
+      await encoder.addFile(File(song.mixture), 'original.wav');
+    } finally {
+      await encoder.close();
+    }
+
+    try {
+      return await _saveFile(
+        output,
+        '${sanitizeFilename(song.title)} - stems.zip',
+      );
+    } finally {
+      await output.deleteIfExists();
+    }
+  }
+
+  Future<bool> _saveFile(File source, String fileName) async {
+    final path = await FilePicker.saveFile(
+      dialogTitle: 'Export from Demixr',
+      fileName: fileName,
+      bytes: Platform.isAndroid || Platform.isIOS
+          ? await source.readAsBytes()
+          : null,
+    );
+    if (path == null) return false;
+    if (!Platform.isAndroid && !Platform.isIOS) {
+      if (p.equals(source.path, path)) return true;
+      await source.copy(path);
+    }
+    return true;
+  }
+
+  String _quote(String value) => '"${value.replaceAll('"', '\\"')}"';
+}

--- a/lib/services/song_export_service.dart
+++ b/lib/services/song_export_service.dart
@@ -26,13 +26,6 @@ class SongExportService {
     final gains = <Stem, double>{
       for (final stem in song.stems) stem: (volumes[stem] ?? 1).clamp(0, 1),
     };
-    if (song.stems.every((stem) => gains[stem] == 1)) {
-      return _saveFile(
-        File(song.mixture),
-        '${sanitizeFilename(song.title)} - remix.wav',
-      );
-    }
-
     final output = File(
       p.join(
         (await getTemporaryDirectory()).path,
@@ -61,9 +54,12 @@ class SongExportService {
     }
 
     try {
+      final profile = song.stems
+          .map((stem) => '${stem.value}${(gains[stem]! * 100).round()}')
+          .join('-');
       return await _saveFile(
         output,
-        '${sanitizeFilename(song.title)} - remix.wav',
+        '${sanitizeFilename(song.title)} - remix-$profile.wav',
       );
     } finally {
       await output.deleteIfExists();

--- a/lib/services/stems_player.dart
+++ b/lib/services/stems_player.dart
@@ -78,16 +78,16 @@ class StemsPlayer {
         stem:
             stemVolumes[stem] ?? (getStemState(stem) == StemState.mute ? 0 : 1),
     };
-    mixtureOn = false;
+    mixtureOn = stemVolumes.values.every((volume) => volume == 1);
 
     _player(Stem.mixture).setSource(DeviceFileSource(song.mixture));
     for (final stem in activeStems) {
       final player = _player(stem)
         ..setSource(DeviceFileSource(song.getStem(stem)));
-      player.setVolume(stemVolumes[stem]!);
+      player.setVolume(mixtureOn ? 0 : stemVolumes[stem]!);
     }
 
-    _player(Stem.mixture).mute();
+    _player(Stem.mixture).setVolume(mixtureOn ? 1 : 0);
   }
 
   void pause() {
@@ -137,7 +137,22 @@ class StemsPlayer {
     final normalized = volume.clamp(0.0, 1.0);
     stemVolumes[stem] = normalized;
     stemStates[stem] = normalized == 0 ? StemState.mute : StemState.unmute;
-    players[stem]?.setVolume(normalized);
+
+    final shouldUseMixture = activeStems.every(
+      (activeStem) => getStemVolume(activeStem) == 1,
+    );
+    if (shouldUseMixture != mixtureOn) {
+      mixtureOn = shouldUseMixture;
+      _player(Stem.mixture).setVolume(mixtureOn ? 1 : 0);
+      for (final activeStem in activeStems) {
+        _player(
+          activeStem,
+        ).setVolume(mixtureOn ? 0 : getStemVolume(activeStem));
+      }
+      return;
+    }
+
+    if (!mixtureOn) players[stem]?.setVolume(normalized);
   }
 }
 

--- a/lib/services/stems_player.dart
+++ b/lib/services/stems_player.dart
@@ -14,6 +14,7 @@ class StemsPlayer {
   /// The stems present in the current song (excludes the mixture).
   List<Stem> activeStems = const [];
   Map<Stem, StemState> stemStates = {};
+  Map<Stem, double> stemVolumes = {};
   bool mixtureOn = false;
   int duration = 0;
 
@@ -72,20 +73,21 @@ class StemsPlayer {
             previousStates[stem] ??
             (stem == Stem.vocals ? StemState.mute : StemState.unmute),
     };
-    mixtureOn = allStemsUnmute;
+    stemVolumes = {
+      for (final stem in activeStems)
+        stem:
+            stemVolumes[stem] ?? (getStemState(stem) == StemState.mute ? 0 : 1),
+    };
+    mixtureOn = false;
 
     _player(Stem.mixture).setSource(DeviceFileSource(song.mixture));
     for (final stem in activeStems) {
       final player = _player(stem)
         ..setSource(DeviceFileSource(song.getStem(stem)));
-      if (mixtureOn || getStemState(stem) == StemState.mute) {
-        player.mute();
-      } else {
-        player.unMute();
-      }
+      player.setVolume(stemVolumes[stem]!);
     }
 
-    mixtureOn ? _player(Stem.mixture).unMute() : _player(Stem.mixture).mute();
+    _player(Stem.mixture).mute();
   }
 
   void pause() {
@@ -125,22 +127,17 @@ class StemsPlayer {
   }
 
   void toggleStem(Stem stem) {
-    if (mixtureOn) {
-      mixtureOn = false;
-      unmuteAll();
-      players[Stem.mixture]?.mute();
-    }
-
     final state = getStemState(stem);
-    players[stem]?.muteToggle(state);
+    setStemVolume(stem, state == StemState.mute ? 1 : 0);
+  }
 
-    stemStates[stem] = state.toggle();
+  double getStemVolume(Stem stem) => stemVolumes[stem] ?? 0;
 
-    if (allStemsUnmute) {
-      mixtureOn = true;
-      muteAll();
-      players[Stem.mixture]?.unMute();
-    }
+  void setStemVolume(Stem stem, double volume) {
+    final normalized = volume.clamp(0.0, 1.0);
+    stemVolumes[stem] = normalized;
+    stemStates[stem] = normalized == 0 ? StemState.mute : StemState.unmute;
+    players[stem]?.setVolume(normalized);
   }
 }
 

--- a/lib/services/system_media_handler.dart
+++ b/lib/services/system_media_handler.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+
+import '../models/unmixed_song.dart';
+
+class SystemMediaHandler extends BaseAudioHandler {
+  Future<void> Function()? onPlay;
+  Future<void> Function()? onPause;
+  Future<void> Function(Duration position)? onSeek;
+  Future<void> Function()? onNext;
+  Future<void> Function()? onPrevious;
+
+  void attach({
+    required Future<void> Function() play,
+    required Future<void> Function() pause,
+    required Future<void> Function(Duration position) seek,
+    required Future<void> Function() next,
+    required Future<void> Function() previous,
+  }) {
+    onPlay = play;
+    onPause = pause;
+    onSeek = seek;
+    onNext = next;
+    onPrevious = previous;
+  }
+
+  void publishSong(UnmixedSong song) {
+    final coverPath = song.coverPath;
+    mediaItem.add(
+      MediaItem(
+        id: song.mixture,
+        title: song.title,
+        artist: song.artists.join(', '),
+        album: 'Demixr · ${song.modelName}',
+        duration: song.duration,
+        artUri: coverPath != null && File(coverPath).existsSync()
+            ? Uri.file(coverPath)
+            : null,
+      ),
+    );
+  }
+
+  void publishState({
+    required bool playing,
+    required Duration position,
+    required Duration bufferedPosition,
+  }) {
+    playbackState.add(
+      playbackState.value.copyWith(
+        controls: [
+          MediaControl.skipToPrevious,
+          playing ? MediaControl.pause : MediaControl.play,
+          MediaControl.skipToNext,
+        ],
+        systemActions: const {MediaAction.seek},
+        androidCompactActionIndices: const [0, 1, 2],
+        processingState: AudioProcessingState.ready,
+        playing: playing,
+        updatePosition: position,
+        bufferedPosition: bufferedPosition,
+        speed: 1,
+      ),
+    );
+  }
+
+  @override
+  Future<void> play() async => onPlay?.call();
+
+  @override
+  Future<void> pause() async => onPause?.call();
+
+  @override
+  Future<void> seek(Duration position) async => onSeek?.call(position);
+
+  @override
+  Future<void> skipToNext() async => onNext?.call();
+
+  @override
+  Future<void> skipToPrevious() async => onPrevious?.call();
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,16 +5,22 @@
 import FlutterMacOS
 import Foundation
 
+import audio_service
+import audio_session
 import audioplayers_darwin
 import ffmpeg_kit_flutter_new_audio
 import file_picker
 import flutter_onnxruntime
+import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
+  AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FFmpegKitFlutterPlugin.register(with: registry.registrar(forPlugin: "FFmpegKitFlutterPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterOnnxruntimePlugin.register(with: registry.registrar(forPlugin: "FlutterOnnxruntimePlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   loadmore: ^2.1.0
   loading_indicator: ^3.1.1
   auto_size_text: ^3.0.0
+  archive: ^4.0.9
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,6 @@ dependencies:
   loadmore: ^2.1.0
   loading_indicator: ^3.1.1
   auto_size_text: ^3.0.0
-  share_plus: ^12.0.1
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   get: ^4.7.3
   async: ^2.13.1
   audioplayers: ^6.8.1
+  audio_service: ^0.18.19
   audio_video_progress_bar: ^2.0.3
   url_launcher: ^6.3.2
   percent_indicator: ^4.2.5
@@ -58,6 +59,7 @@ dependencies:
   loadmore: ^2.1.0
   loading_indicator: ^3.1.1
   auto_size_text: ^3.0.0
+  share_plus: ^12.0.1
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
 


### PR DESCRIPTION
## What changed

- added draggable per-stem volume mixer bars
- restored original-mixture playback when every stem is at 100%
- added system media metadata and previous/play/pause/next/seek controls on Android, iOS, and macOS
- added export options for the current remix, original song, individual stems, and all stems as a ZIP
- ensured current-remix exports always render the captured stem levels and include the mix profile in the filename

## Why

Demixr playback previously supported only binary stem muting and could not integrate with system media surfaces or create user-accessible exports. The new mixer enables actual remix levels while retaining the higher-quality original-file shortcut when no remix is active.

## Impact

Users can control playback from Android media notifications, Apple Control Center, headset buttons, and macOS Now Playing. They can mix stems continuously and export the result or source files through the native save dialog without duplicating the private library automatically.

## Validation

- `flutter analyze`
- `flutter test` (8 tests)
- Android debug APK build and runtime media-session inspection
- system-dispatched Android Play command verified as `PLAYING` with live metadata and position
- iOS simulator debug build
- macOS debug build and launch
