### PR TITLE
Fix Android Vulkan model failures

### DIFF
--- a/lib/helpers/separation/executorch_demixing_engine.dart
+++ b/lib/helpers/separation/executorch_demixing_engine.dart
@@ -38,7 +38,16 @@ class ExecuTorchDemixingEngine {
     await _model?.dispose();
     _model = null;
     _modelPath = null;
-    final m = await ExecuTorchModel.load(corePath);
+    late final ExecuTorchModel m;
+    try {
+      m = await ExecuTorchModel.load(corePath);
+    } on ExecuTorchException catch (error) {
+      debugPrint('ExecuTorch model load failed: $error');
+      throw DemixingException(
+        'GPU acceleration could not start on this device. '
+        'Please select the CPU model in settings.',
+      );
+    }
     _model = m;
     _modelPath = corePath;
     return m;

--- a/lib/providers/demixing_provider.dart
+++ b/lib/providers/demixing_provider.dart
@@ -39,15 +39,23 @@ class DemixingProvider extends ChangeNotifier {
 
     _progressStream = _helper.progressStream;
 
-    separate(song)
-        ?.then((unmixed) => library.saveSong(unmixed))
-        .then((index) => library.setCurrentSongIndex(index))
-        .then(
-          (_) => Get.offAllNamed(
-            '/player',
-            predicate: (route) => route.settings.name == '/',
-          ),
-        );
+    final operation = separate(song);
+    if (operation == null) return;
+    try {
+      final unmixed = await operation.valueOrCancellation();
+      if (unmixed == null) return;
+      final index = await library.saveSong(unmixed);
+      library.setCurrentSongIndex(index);
+      Get.offAllNamed(
+        '/player',
+        predicate: (route) => route.settings.name == '/',
+      );
+    } on DemixingException catch (error) {
+      errorSnackbar('Demixing error', error.message, seconds: 5);
+      if (Get.currentRoute == '/demixing/processing') Get.back();
+    } finally {
+      _operation = null;
+    }
   }
 
   /// Creates a cancelable async operation for the separation of the [song].
@@ -58,13 +66,7 @@ class DemixingProvider extends ChangeNotifier {
     Get.toNamed('/demixing/processing', arguments: this);
 
     _operation = CancelableOperation<UnmixedSong>.fromFuture(
-      _helper
-          .separate(song, preferences.getModelPath(), preferences.modelName)
-          .onError((DemixingException error, _) {
-            errorSnackbar('Demixing error', error.message, seconds: 5);
-            cancelDemixing();
-            throw error;
-          }),
+      _helper.separate(song, preferences.getModelPath(), preferences.modelName),
     );
     return _operation;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,17 @@ dependency_overrides:
   flutter_onnxruntime:
     path: third_party/flutter_onnxruntime
 
+# Android needs the opt-in Vulkan runtime for the GPU-delegated HTDemucs
+# artifact. Unsupported backends are filtered per platform by the plugin:
+# Android gets XNNPACK + Vulkan, while Apple also gets Core ML.
+hooks:
+  user_defines:
+    executorch_flutter:
+      backends:
+        - xnnpack
+        - coreml
+        - vulkan
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## What changed

- Package the ExecuTorch Vulkan backend on Android while retaining XNNPACK and platform-filtered Core ML support.
- Convert ExecuTorch model-load failures into a clear GPU compatibility error.
- Await demixing operations directly so failures close the processing screen instead of leaving an indefinite spinner.

## Root cause

The Android build did not include the opt-in Vulkan runtime required by the GPU-delegated HTDemucs artifact. After enabling it, the Android emulator reaches Vulkan initialization but rejects the model with `Expected TensorRef, got TENSOR`; the emulator also reports that it cannot open a Mesa render node. A physical Vulkan-capable Android device is therefore still required to validate the model/runtime combination.

## Validation

- `flutter analyze` passed for the touched Dart files.
- Focused model and widget tests passed (9 tests).
- Android debug APK built successfully for the connected ARM64 emulator.
- Build output confirms the `xnnpack-vulkan` ExecuTorch native variant is packaged.
- Emulator test confirms failures now surface cleanly rather than spinning indefinitely.

## Remaining work

- Validate HTDemucs Vulkan model loading and separation on a physical Android device.
- Keep this PR in draft until that hardware test is complete.